### PR TITLE
Refactors `is None` validation to `not`

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -60,7 +60,7 @@ def create_payment_link():
     k2connect.initialize(environ.get('CLIENT_ID'), environ.get('CLIENT_SECRET'), BASE_URL)
     payment_links_service = k2connect.PaymentLinks(access_token=environ.get('ACCESS_TOKEN'))
     payment_link_request = {
-        "currency": "KES",
+        "currency": request.form["payment-link-currency"],
         "amount": request.form["amount"],
         "till_number": request.form["till-number"],
         "payment_reference": request.form["payment-reference"],

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -1069,7 +1069,7 @@
                             <h5>Initiate a reversal</h5>
                         </div>
 
-                        <form id="payment-links" method="post" action="{{ url_for('initiate_reversal') }}">
+                        <form id="reversals" method="post" action="{{ url_for('initiate_reversal') }}">
                             <div id="initiate-reversal-form" class="reversals-form">
                                 <div class="form-row">
                                     <div class="form-group col-6">

--- a/k2connect/models/destination/external_destination.py
+++ b/k2connect/models/destination/external_destination.py
@@ -20,9 +20,9 @@ class ExternalDestination(ABC):
     def validate(self):
         if not self.type:
             raise ValidationError("Field 'type' must be present.")
-        if self.amount is None:
+        if not self.amount:
             raise ValidationError("Field 'amount' must be present.")
-        if self.description is None:
+        if not self.description:
             raise ValidationError("Field 'description' must be present.")
 
     @abc.abstractmethod

--- a/k2connect/models/destination/internal_destination.py
+++ b/k2connect/models/destination/internal_destination.py
@@ -15,7 +15,7 @@ class InternalDestination(ABC):
     def validate(self):
         if not self.type:
             raise ValidationError("Field 'type' must be present.")
-        if self.amount is None:
+        if not self.amount:
             raise ValidationError("Field 'amount' must be present.")
 
     @abstractmethod

--- a/k2connect/models/incoming_payments/incoming_payment_request.py
+++ b/k2connect/models/incoming_payments/incoming_payment_request.py
@@ -53,7 +53,7 @@ class IncomingPaymentRequest:
         if not self.till_number:
             raise ValueError("till_number is required")
 
-        if self.subscriber.phone_number is None:
+        if not self.subscriber.phone_number:
             raise ValueError("subscriber phone_number is required")
 
         if not self.callback_url:

--- a/k2connect/models/payment_links/payment_link_request.py
+++ b/k2connect/models/payment_links/payment_link_request.py
@@ -31,14 +31,14 @@ class PaymentLinkRequest:
         }
 
     def validate(self):
-        if self.amount is None:
+        if not self.amount:
             raise ValueError("amount is required")
 
-        if self.currency is None:
+        if not self.currency:
             raise ValueError("currency is required")
 
-        if self.till_number is None:
+        if not self.till_number:
             raise ValueError("till_number is required")
 
-        if self.callback_url is None:
+        if not self.callback_url:
             raise ValueError("callback_url is required")

--- a/k2connect/models/polling/polling_request.py
+++ b/k2connect/models/polling/polling_request.py
@@ -32,16 +32,16 @@ class PollingRequest:
         }
 
     def validate(self):
-        if self.from_time is None:
+        if not self.from_time:
             raise ValueError("from_time is required")
 
-        if self.to_time is None:
+        if not self.to_time:
             raise ValueError("to_time is required")
 
-        if self.callback_url is None:
+        if not self.callback_url:
             raise ValueError("callback_url is required")
 
-        if self.scope is None:
+        if not self.scope:
             raise ValueError("scope is required")
 
         if self.scope not in {"till", "company"}:

--- a/k2connect/models/reversals/reversal_request.py
+++ b/k2connect/models/reversals/reversal_request.py
@@ -32,7 +32,7 @@ class ReversalRequest:
         if not self.transaction_reference:
             self.errors.append("transaction_reference is required.")
 
-        if self.reason is None:
+        if not self.reason:
             self.errors.append("reason is required.")
 
         if self.errors:

--- a/k2connect/models/webhook/webhook_subscription_request.py
+++ b/k2connect/models/webhook/webhook_subscription_request.py
@@ -26,13 +26,13 @@ class WebhookSubscriptionRequest:
         }
 
     def validate(self):
-        if self.event_type is None:
+        if not self.event_type:
             raise ValueError("event_type is required")
 
-        if self.scope is None:
+        if not self.scope:
             raise ValueError("scope is required")
 
-        if self.url is None:
+        if not self.url:
             raise ValueError("url is required")
 
         if self.event_type not in {"buygoods_transaction_received", "b2b_transaction_received",


### PR DESCRIPTION
## Background of changes

_Please include a summary of the changes being introduced by this PR._

- Refactors `is None` validation to `not` to take care of empty springs. The former passes for an empty string, while the latter fails for both a None object and an empty string


## Type of change

_Please tick off the options that apply._

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update
- [ ] This change requires Postman collection update
- [ ] This change requires updating the DEPLOYMENT_CHECKLIST

## Checklist

_Please tick off the options that apply._

- [x] My changes work as expected
- [x] I have performed a self-review of my code
- [ ] I have updated the DEPLOYMENT_CHECKLIST
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to Postman collection
- [ ] I have added automated tests that prove my fix is effective or that my feature works as expected

## How has this been tested?

_Please outline the scenarios that were tested (Add screenshots if necessary)_

<img width="477" height="204" alt="image" src="https://github.com/user-attachments/assets/590bf926-e7c4-4eda-be54-612249bf0f3f" />


