### PR TITLE
fix(KK-12115): Remove double url formatting for query transaction status

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -142,7 +142,8 @@ def query_send_money_payment():
     send_money_service = k2connect.SendMoney(access_token=environ.get('ACCESS_TOKEN'))
 
     send_money_resource_location = send_money_service.query_resource(resource_url)
-    return render_template('payment.html', resource_location_url=send_money_resource_location)
+    formatted_json_response = json.dumps(send_money_resource_location, indent=2)
+    return render_template('send_money.html', resource_location_url=formatted_json_response)
 
 
 @app.route('/merchant_transfer_account', methods=['POST'])

--- a/example/templates/send_money.html
+++ b/example/templates/send_money.html
@@ -56,11 +56,11 @@
 	</div>
 
     <div class="container">
-        <!--payments sections header-->
+        <!--send money sections header-->
         <div class="section-header">
-            <h2>Payments</h2>
+            <h2>Send Money</h2>
         </div>
-        <!--close payments sections header-->
+        <!--close send money sections header-->
 
         <div class="row">
             <div class="col-lg-9">
@@ -78,7 +78,15 @@
                     </tr>
                     </thead>
                     <tr>
-                        <td>{{ resource_location_url }}</td>
+                        <td>
+                            <pre style="
+                            background: #f4f4f4;
+                            padding: 10px;
+                            border-radius: 4px;
+                            overflow-y: auto;
+                            white-space: pre-wrap;
+                            word-break: break-all;"><code>{{resource_location_url}}</code></pre>
+                        </td>
                     </tr>
                 </table>
             </div>

--- a/k2connect/base_service.py
+++ b/k2connect/base_service.py
@@ -10,4 +10,4 @@ class BaseService(K2Requests):
         return self.base_url + url_path
 
     def query_resource(self, resource_url):
-        return self._query_transaction_status(headers=self._headers, query_url=self._build_url(resource_url))
+        return self._query_transaction_status(headers=self._headers, query_url=resource_url)

--- a/k2connect/k2_requests_v2.py
+++ b/k2connect/k2_requests_v2.py
@@ -12,7 +12,7 @@ class K2Requests:
             'Accept': 'application/vnd.kopokopo.v4.hal+json',
             'Content-Type': 'application/json',
             'User-Agent': 'Kopokopo-Python-SDK',
-            'Authorization': f"Bearer #{access_token}"
+            'Authorization': f"Bearer {access_token}"
         }
 
     @staticmethod


### PR DESCRIPTION
## Background of changes

_Please include a summary of the changes being introduced by this PR._

- Removes double url formatting for query transaction status
- Formats send money html to correctly render JSON text


## Type of change

_Please tick off the options that apply._

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update
- [ ] This change requires Postman collection update
- [ ] This change requires updating the DEPLOYMENT_CHECKLIST

## Checklist

_Please tick off the options that apply._

- [x] My changes work as expected
- [x] I have performed a self-review of my code
- [ ] I have updated the DEPLOYMENT_CHECKLIST
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to Postman collection
- [ ] I have added automated tests that prove my fix is effective or that my feature works as expected

## How has this been tested?

_Please outline the scenarios that were tested (Add screenshots if necessary)_

<img width="1004" height="798" alt="image" src="https://github.com/user-attachments/assets/4135b975-e875-425e-9eff-b48803723abb" />


